### PR TITLE
Changed name from "EvoThingsStudio" to "EvoThings Workbench".

### DIFF
--- a/package-template.json
+++ b/package-template.json
@@ -1,6 +1,6 @@
 {
   "main": "hyper/ui/hyper-ui.html",
-  "name": "EvoThingsStudio",
+  "name": "EvoThings Workbench",
   "description": "HTML/JS IoT mobile app development tool",
   "version": "__VERSION__",
   "keywords": ["EvoThings Studio", "mobile", "JavaScript"],


### PR DESCRIPTION
The name defined in package-template.json and that was changed shows e.g. in the node-webkit menu bar. As it was previously decided that the EvoThings suite of applications is named EvoThings Studio and the desktop app called EvoThings Workbench.
