### PR TITLE
fixed issue #107 broken user message regression

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/ruby
+
 # Build a distribution package of Evothings Studio.
 # Author: Mikael Kindborg
 

--- a/hyper/server/hyper-server.js
+++ b/hyper/server/hyper-server.js
@@ -42,7 +42,7 @@ var APP_SETTINGS = require('./app-settings.js')
 
 // Workbench version code should be incremented on each new release.
 // The version code can be used by the server to display info.
-var mWorkbenchVersionCode = 5
+var mWorkbenchVersionCode = 1
 
 // Version of the server message protocol implemented on top of socket.io.
 // Increment when the protocol has changed.
@@ -187,10 +187,11 @@ function onMessageWorkbenchSetSessionID(socket, message)
 	{
 		// Pass the message to the callback function,
 		// this displays the message in the UI.
+		EVENTS.publish(EVENTS.USERMESSAGE, message.userMessage)
 		mStatusCallback && mStatusCallback({
 			event: 'user-message',
 			userMessage: message.userMessage })
-        EVENTS.publish(EVENTS.USERMESSAGE, message.userMessage)
+
 	}
 }
 
@@ -256,8 +257,9 @@ function onMessageWorkbenchUserMessage(socket, message)
 	{
 		// Pass the message to the callback function,
 		// this displays the message in the UI.
+		EVENTS.publish(EVENTS.USERMESSAGE, message.userMessage)
 		mStatusCallback && mStatusCallback({
-			event: 'user-message',
+			event: 'workbench.user-message',
 			userMessage: message.userMessage })
 	}
 }

--- a/hyper/server/hyper-server.js
+++ b/hyper/server/hyper-server.js
@@ -42,7 +42,7 @@ var APP_SETTINGS = require('./app-settings.js')
 
 // Workbench version code should be incremented on each new release.
 // The version code can be used by the server to display info.
-var mWorkbenchVersionCode = 1
+var mWorkbenchVersionCode = 5
 
 // Version of the server message protocol implemented on top of socket.io.
 // Increment when the protocol has changed.

--- a/hyper/ui/hyper-ui.js
+++ b/hyper/ui/hyper-ui.js
@@ -1557,10 +1557,11 @@ hyper.UI.setupUIEvents = function()
         hyper.UI.displayConnectStatus('Disconnected')
     })
 
-    EVENTS.subscribe(EVENTS.USERMESSAGE, function(obj)
+    EVENTS.subscribe(EVENTS.USERMESSAGE, function(message)
     {
         // Display a message for the user.
-        hyper.UI.displayConnectScreenMessage(message.userMessage)
+        hyper.UI.displayConnectScreenMessage(message)
+	    hyper.UI.showTab('connect')
     })
 }
 


### PR DESCRIPTION
Also added a fix for the ruby build script, but mostly this fixed a bug I introduced when streamlining events and stuff, which left the user-message event dangling. I also added a tab switch to the 'connect' tab where the user message (if any) is shown.