### PR TITLE
Replace backslashes with frontslashes on image paths.

### DIFF
--- a/hyper/ui/hyper-ui.js
+++ b/hyper/ui/hyper-ui.js
@@ -341,6 +341,7 @@ hyper.UI.defineUIFunctions = function()
 		if (imagePath)
 		{
 			var fullImagePath = PATH.join(appPath, imagePath)
+			fullImagePath = fullImagePath.replace(/\\/g, '/')
 			html += '<div class="app-icon" style="background-image: url(\'file://' +
 				fullImagePath + '\');"></div>'
 		}


### PR DESCRIPTION
This fixes a bug where example icons could not be loaded on Windows.