### PR TITLE
Corrected getEvothingsUserFolderPath().

### DIFF
--- a/hyper/server/fileutil.js
+++ b/hyper/server/fileutil.js
@@ -98,8 +98,8 @@ exports.getEvothingsUserFolderPath = function()
 	{
 		var userDir =
 			process.env.HOME ||
-			process.env.HOMEPATH ||
-			process.env.USERPROFILE
+			process.env.USERPROFILE ||
+			(process.env.HOMEDRIVE && process.env.HOMEPATH) ? (process.env.HOMEDRIVE + process.env.HOMEPATH) : false
 		var myAppsDir = PATH.join(
 			userDir, 'EvothingsStudio', 'MyApps')
 		return myAppsDir


### PR DESCRIPTION
HOMEPATH alone on Windows will not work; you need HOMEDRIVE too.
Increased priority of USERPROFILE.